### PR TITLE
Fix spacing for country-picker.js

### DIFF
--- a/frontend/src/components/profile/country-picker.js
+++ b/frontend/src/components/profile/country-picker.js
@@ -99,7 +99,7 @@ class CountryPicker extends Component {
           <DialogTitle id='alert-dialog-title'>{ 'Choose your country' }</DialogTitle>
           <DialogContent>
             <DialogContentText id='alert-dialog-description'>
-            Please choose the country that you have your bank account to receive your bounties when conclude any task
+              Please choose the country that you have your bank account to receive your bounties when conclude any task
             </DialogContentText>
             <div className={ classes.countryContainer }>
               { countryCodes.map((item) => {


### PR DESCRIPTION
## Description

> When running tests with ```npm run test```, it fails with this message:

```
/home/vagrant/gitpay/frontend/src/components/profile/country-picker.js
101:62  error  Expected indentation of 14 space characters but found 12  react/jsx-indent
✖ 1 problem (1 error, 0 warnings)
1 error, 0 warnings potentially fixable with the `--fix` option.
```

## Changes

- [ frontend/src/components/profile/country-picker.js ] fixed the spacing on line 101

## Related Issue

> #000

## Impacted Area

> cli test

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

- run ```npm run test```
- observe that the test is now successful
